### PR TITLE
ci: Add deepsource test coverage report job

### DIFF
--- a/.github/workflows/deepsource.yml
+++ b/.github/workflows/deepsource.yml
@@ -1,0 +1,30 @@
+name: DeepSource Test Coverage
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "19 7 * * 2"
+
+jobs:
+  go-test:
+    name: Go Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+      - name: Report test-coverage to DeepSource
+        run: |
+          go test -coverprofile=${COVERAGE_FILE} -v ./...
+          curl https://deepsource.io/cli | sh
+          ./bin/deepsource report --analyzer test-coverage --key $LANGUAGE_KEY --value-file ${COVERAGE_FILE}
+        env:
+          DEEPSOURCE_DSN: ${{ secrets.DEEPSOURCE_DSN }}
+          COVERAGE_FILE: cover.out
+          LANGUAGE_KEY: go


### PR DESCRIPTION
Add GitHub Action workflow to create go test coverage reports to deepsource.
