### PR TITLE
fix: Checkout repo before labeling PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
 
     steps:
+      - uses: actions/checkout@v3.3.0
       - name: Get PR number
         id: pr
         run: |


### PR DESCRIPTION
The gh cli complains that it is not running in a git directory.
