### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@
 # you can turn it on using a cron schedule for regular testing.
 #
 name: Tests
+permissions:
+  contents: read
 on:
   pull_request:
     paths-ignore:


### PR DESCRIPTION
Potential fix for [https://github.com/gonzolino/terraform-provider-tado/security/code-scanning/11](https://github.com/gonzolino/terraform-provider-tado/security/code-scanning/11)

Add an explicit `permissions` block at the workflow root in `.github/workflows/test.yml`, directly under `name` (or before `jobs`).  
Best minimal fix without changing functionality: set:

- `contents: read`

This grants only read access to repository contents for all jobs unless overridden, which is sufficient for `actions/checkout`, building, generating, and testing shown here. No new imports/methods/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
